### PR TITLE
Current version prevented to compile shaka player locally

### DIFF
--- a/lib/dash/mpd_processor.js
+++ b/lib/dash/mpd_processor.js
@@ -1143,14 +1143,6 @@ shaka.dash.MpdProcessor.prototype.makeSegmentIndexSourceViaIndexUrlTemplate_ =
     return null;
   }
 
-  // Generate the media URL.
-//  var mediaUrl = shaka.dash.MpdUtils.createFromTemplate(
-//      networkCallback, representation, 1, 0, 0, null);
-//  if (!mediaUrl) {
-    // An error has already been logged.
-  //  return null;
-  //}
-
   // Generate a RepresentationIndex.
   var representationIndex = this.generateRepresentationIndex_(representation);
   if (!representationIndex) {
@@ -1275,4 +1267,3 @@ shaka.dash.MpdProcessor.prototype.createSegmentMetadata_ = function(
 
   return new shaka.util.FailoverUri(networkCallback, url, startByte, endByte);
 };
-

--- a/lib/dash/mpd_utils.js
+++ b/lib/dash/mpd_utils.js
@@ -97,8 +97,6 @@ shaka.dash.MpdUtils.generateSegmentReferences = function(
 };
 
 
-
-
 /**
  * Creates a FailoverUri from a relative template URL.
  *
@@ -108,7 +106,8 @@ shaka.dash.MpdUtils.generateSegmentReferences = function(
  * @param {number} time
  * @param {number} startByte
  * @param {?number} endByte
- * @return {shaka.util.FailoverUri} or pointer to function which return shaka.util.FailoverUri in case deferring filling URI templates
+ * @return {shaka.util.FailoverUri} or pointer to function
+ * which return shaka.util.FailoverUri in case deferring filling URI templates
  */
 shaka.dash.MpdUtils.createFromTemplate = function(
     networkCallback, representation, number, time, startByte, endByte) {
@@ -127,8 +126,6 @@ shaka.dash.MpdUtils.createFromTemplate = function(
         null;
   }
 
- 
-  var fillUrlTemplateFunction= function() {
   var filledUrlTemplate = shaka.dash.MpdUtils.fillUrlTemplate(
       urlTemplate,
       representation.id,
@@ -139,14 +136,14 @@ shaka.dash.MpdUtils.createFromTemplate = function(
     // An error has already been logged.
     return null;
   }
+
   var mediaUrl = shaka.util.FailoverUri.resolve(
       representation.baseUrl, filledUrlTemplate);
-  return new shaka.util.FailoverUri(
-      networkCallback, mediaUrl, startByte, endByte);
-      
-  }
 
-  return fillUrlTemplateFunction;
+  return mediaUrl ?
+      new shaka.util.FailoverUri(
+         networkCallback, mediaUrl, startByte, endByte) :
+         null;
 };
 
 
@@ -155,12 +152,12 @@ shaka.dash.MpdUtils.createFromTemplate = function(
  *
  * @see ISO/IEC 23009-1:2014 section 5.3.9.4.4
  *
- * @param {string} urlTemplate
+ * @param {?string} urlTemplate
  * @param {?string} representationId
  * @param {?number} number
  * @param {?number} bandwidth
  * @param {?number} time
- * @return {goog.Uri} A URL on success; otherwise, return null.
+ * @return {?goog.Uri} A URL on success; otherwise, return null.
  */
 shaka.dash.MpdUtils.fillUrlTemplate = function(
     urlTemplate, representationId, number, bandwidth, time) {

--- a/lib/media/source_buffer_manager.js
+++ b/lib/media/source_buffer_manager.js
@@ -248,11 +248,11 @@ shaka.media.SourceBufferManager.prototype.fetch = function(
   }
 
   var mediaUrl;
-  if (typeof(reference.url)=='function') { //deffered initialization
-      mediaUrl=reference.url.call();
+  if (typeof(reference.url) == 'function') { //deffered initialization
+    mediaUrl = reference.url.call();
   }
   else {
-      mediaUrl=reference.url;
+    mediaUrl = reference.url;
   }
 
   if (shaka.features.Offline &&
@@ -679,4 +679,3 @@ if (!COMPILED) {
     return 'SBM ' + this.mimeType_ + ':';
   };
 }
-

--- a/lib/util/content_database_writer.js
+++ b/lib/util/content_database_writer.js
@@ -427,12 +427,12 @@ shaka.util.ContentDatabaseWriter.prototype.requestSegment_ = function(
   var params = new shaka.util.AjaxRequest.Parameters();
   params.requestTimeoutMs = this.segmentRequestTimeout_ * 1000;
   var mediaUrl;
-  if (typeof(reference.url)=='function') { //deffered initialization
-      mediaUrl=reference.url.call();
+  if (typeof(reference.url) == 'function') { //deffered initialization
+    mediaUrl = reference.url.call();
   }
   else {
-      mediaUrl=reference.url;
-  }  
+    mediaUrl = reference.url;
+  }
   return /** @type {!Promise.<!ArrayBuffer>} */ (
       mediaUrl.fetch(params, this.estimator_));
 };
@@ -463,4 +463,3 @@ shaka.util.ContentDatabaseWriter.prototype.deleteStream_ = function(streamId) {
   store.transaction.oncomplete = function(e) { p.resolve(); };
   return p;
 };
-


### PR DESCRIPTION
fixed 39 errors provided by linting system
fixed in mpd_utils wrong documentation that triggered an error at compile time
fixed in mpd_utils fillUrlTemplateFunction that was returning a function instead of FailoverUri object or null and triggered an error at compile time
